### PR TITLE
Enhance hot_or_not functionality by adding avg_reference_predicted_ds…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ diagnostic_test_queries.sql
 
 prod.env
 roles.sql
+check_distribution_ds_score.py

--- a/cron.sql
+++ b/cron.sql
@@ -2,4 +2,6 @@ CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 SELECT cron.schedule('compute_hot_or_not', '*/1 * * * *', 'SELECT hot_or_not_evaluator.compute_hot_or_not()');
 
+SELECT cron.schedule('update_avg_reference_predicted_ds_score', '0 0 */3 * *', 'SELECT hot_or_not_evaluator.update_avg_reference_predicted_ds_score()');
+
 SELECT * FROM cron.job;

--- a/migration_add_hot_or_not_windows.sql
+++ b/migration_add_hot_or_not_windows.sql
@@ -4,6 +4,7 @@
 -- This migration adds 3 new boolean columns and 3 new numeric columns to track
 -- hot_or_not status and average ds_scores for historical 5-minute windows.
 -- this migration adds a new function to get the hot-or-not status for a video
+-- Also adds avg_reference_predicted_ds_score column to metric_const table
 
 
 BEGIN;
@@ -25,6 +26,16 @@ ADD COLUMN avg_ds_score_10_to_15_mins_ago NUMERIC(10, 5) DEFAULT NULL;
 
 ALTER TABLE hot_or_not_evaluator.video_hot_or_not_status 
 ADD COLUMN avg_ds_score_15_to_20_mins_ago NUMERIC(10, 5) DEFAULT NULL;
+
+ALTER TABLE hot_or_not_evaluator.metric_const 
+ADD COLUMN avg_reference_predicted_ds_score NUMERIC DEFAULT NULL;
+
+-- Add columns for efficient incremental updates
+ALTER TABLE hot_or_not_evaluator.metric_const 
+ADD COLUMN avg_reference_predicted_ds_score_count BIGINT DEFAULT 0;
+
+ALTER TABLE hot_or_not_evaluator.metric_const 
+ADD COLUMN avg_reference_predicted_ds_score_last_updated TIMESTAMPTZ DEFAULT NULL;
 
 COMMENT ON COLUMN hot_or_not_evaluator.video_hot_or_not_status.hot_or_not IS 
 'The classification result for current window (0 to -5 mins): TRUE for Hot, FALSE for Not.';
@@ -49,6 +60,15 @@ COMMENT ON COLUMN hot_or_not_evaluator.video_hot_or_not_status.avg_ds_score_10_t
 
 COMMENT ON COLUMN hot_or_not_evaluator.video_hot_or_not_status.avg_ds_score_15_to_20_mins_ago IS 
 'The average ds_score for the -15 to -20 minutes window.';
+
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score IS 
+'Average of reference_predicted_avg_ds_score across all videos, updated periodically.';
+
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score_count IS 
+'Count of videos used in the average calculation for incremental updates.';
+
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score_last_updated IS 
+'Timestamp of the last update to the average reference predicted ds score.';
 
 COMMENT ON TABLE hot_or_not_evaluator.video_hot_or_not_status IS 
 'Stores the latest calculated Hot or Not status for each video with historical 5-minute window scores.';

--- a/schema.sql
+++ b/schema.sql
@@ -16,6 +16,9 @@ CREATE TABLE IF NOT EXISTS hot_or_not_evaluator.metric_const (
     like_ctr_range NUMERIC NOT NULL,
     watch_percentage_center NUMERIC NOT NULL,
     watch_percentage_range NUMERIC NOT NULL,
+    avg_reference_predicted_ds_score NUMERIC DEFAULT NULL,
+    avg_reference_predicted_ds_score_count BIGINT DEFAULT 0,
+    avg_reference_predicted_ds_score_last_updated TIMESTAMPTZ DEFAULT NULL,
     CONSTRAINT single_row CHECK (id = 1)
 );
 
@@ -24,6 +27,9 @@ COMMENT ON COLUMN hot_or_not_evaluator.metric_const.like_ctr_center IS 'Center v
 COMMENT ON COLUMN hot_or_not_evaluator.metric_const.like_ctr_range IS 'Range value for normalizing cumulative like CTR.';
 COMMENT ON COLUMN hot_or_not_evaluator.metric_const.watch_percentage_center IS 'Center value for normalizing cumulative average watch percentage.';
 COMMENT ON COLUMN hot_or_not_evaluator.metric_const.watch_percentage_range IS 'Range value for normalizing cumulative average watch percentage.';
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score IS 'Average of reference_predicted_avg_ds_score across all videos, updated periodically.';
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score_count IS 'Count of videos used in the average calculation for incremental updates.';
+COMMENT ON COLUMN hot_or_not_evaluator.metric_const.avg_reference_predicted_ds_score_last_updated IS 'Timestamp of the last update to the average reference predicted ds score.';
 
 INSERT INTO hot_or_not_evaluator.metric_const (like_ctr_center, like_ctr_range, watch_percentage_center, watch_percentage_range)
 VALUES (0, 0.05, 0, 0.9); -- to update this later in order to upsert instead of insert


### PR DESCRIPTION
…_score column to metric_const table, updating schema and migration scripts. Introduce a new cron job to update the average score every three days and implement a stored procedure for efficient incremental updates.