### PR TITLE
Add video comparison functionality to hot_or_not evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ diagnostic_test_queries.sql
 prod.env
 roles.sql
 check_distribution_ds_score.py
+CLAUDE.md


### PR DESCRIPTION
Introduced a new stored procedure to compare videos and determine their hot/not status based on scores. The procedure handles cases where video scores are missing by generating random scores and storing them in the database.